### PR TITLE
Remove Ultraloq

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -161,7 +161,7 @@
               width="200"
             />
             <img
-              src="https://brands.home-assistant.io/brands/ultraloq/logo.png"
+              src="https://brands.home-assistant.io/brands/jasco/logo.png"
               width="200"
             />
             <img

--- a/public/index.html
+++ b/public/index.html
@@ -165,10 +165,6 @@
               width="200"
             />
             <img
-              src="https://brands.home-assistant.io/brands/jasco/logo.png"
-              width="200"
-            />
-            <img
               src="https://brands.home-assistant.io/brands/heltun/logo.png"
               width="200"
             />


### PR DESCRIPTION
We have canceled the partnership with Ultraloq as their devices do not correctly follow the Z-Wave specification and they are unable to address this.